### PR TITLE
[Fix]: ROS2 Timestep calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ extrinsics_std: [1.0e-2, 1.0e-2, 1.0e-2, 1.0e-2, 1.0e-2, 1.0e-2]
 intrinsics_std: [1.0, 1.0, 1.0, 1.0]
 
 # IMU noise statistics
-accelerometer_noise_density: 1.0-2
+accelerometer_noise_density: 1.0e-2
 accelerometer_random_walk:   1.0e-3
 gyroscope_noise_density: 1.0e-3
 gyroscope_random_walk:   1.0e-4

--- a/wrappers/ros/ros2/include/msceqf_ros.hpp
+++ b/wrappers/ros/ros2/include/msceqf_ros.hpp
@@ -88,14 +88,9 @@ private:
    */
   static rclcpp::Time fromSec(double t)
   {
-    int64_t sec64 = static_cast<int64_t>(floor(t));
-    if (sec64 < 0 || sec64 > std::numeric_limits<uint32_t>::max())
-      throw std::runtime_error("Time is out of dual 32-bit range");
-    uint32_t sec = static_cast<uint32_t>(sec64);
-    uint32_t nsec = static_cast<uint32_t>(std::round((t - sec) * 1e9));
-    sec += (nsec / 1000000000ul);
-    nsec %= 1000000000ul;
-    return rclcpp::Time(sec, nsec);
+    const auto sec = std::chrono::duration<double>(t);
+    const auto nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(sec);
+    return rclcpp::Time(nsec.count());
   }
 
   std::shared_ptr<rclcpp::Node> node_; //<! ROS node

--- a/wrappers/ros/ros2/source/msceqf_ros.cpp
+++ b/wrappers/ros/ros2/source/msceqf_ros.cpp
@@ -74,7 +74,7 @@ void MSCEqFRos::callback_image(const sensor_msgs::msg::Image::SharedPtr msg)
 
   msceqf::Camera cam;
 
-  cam.timestamp_ = cv_ptr->header.stamp.sec + 1.0e9 * cv_ptr->header.stamp.nanosec;
+  cam.timestamp_ = cv_ptr->header.stamp.sec + 1.0e-9 * cv_ptr->header.stamp.nanosec;
   cam.image_ = cv_ptr->image.clone();
 
   {
@@ -88,7 +88,7 @@ void MSCEqFRos::callback_imu(const sensor_msgs::msg::Imu::SharedPtr msg)
 {
   msceqf::Imu imu;
 
-  auto timestamp = msg->header.stamp.sec + 1.0e9 * msg->header.stamp.nanosec;
+  auto timestamp = msg->header.stamp.sec + 1.0e-9 * msg->header.stamp.nanosec;
 
   imu.timestamp_ = timestamp;
   imu.ang_ << msg->angular_velocity.x, msg->angular_velocity.y, msg->angular_velocity.z;


### PR DESCRIPTION
As mentioned in #12 there are some problems with the timesteps when trying to apply the package with ROS2. First I applied the suggested change to the `fromSec` made by @geoeo in #12. Additionally the timestep calculation `callback_image` and `callback_imu` was multiplying the nanoseconds with `1.0e9` instead of `1.0e-9`.

Closes #12