### PR TITLE
[Fix]: Build fails with GCC 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ $ sudo apt install -y nvidia-docker2
 $ sudo systemctl restart docker
 $ cd <path_to_msceqf_folder>
 $ export ROS_VERSION=<Version>  # Enter either 1 or 2 (e.g. ROS_VERSION=1)
-$ docker build --network=host -t msceqf:ros$ROS_VERSION -f docker/Dockerfile_ros$ROS_VERSION
+$ docker build --network=host -t msceqf:ros$ROS_VERSION -f docker/Dockerfile_ros$ROS_VERSION .
 $ xhost +
 $ docker run --net=host -it --gpus all --env="NVIDIA_DRIVER_CAPABILITIES=all" --env="DISPLAY" --env="QT_X11_NO_MITSHM=1" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" msceqf:ros$ROS_VERSION .
 ```

--- a/docker/Dockerfile_ros2
+++ b/docker/Dockerfile_ros2
@@ -7,7 +7,7 @@ RUN mkdir -p /root/ws/src/msceqf
 COPY . /root/ws/src/msceqf/
 
 RUN apt update
-RUN echo 'source /root/ws/devel/setup.bash' >> /root/.bashrc
+RUN echo 'source /root/ws/install/setup.bash' >> /root/.bashrc
 RUN /bin/bash -c "source /root/.bashrc"
 
 WORKDIR /root

--- a/include/msceqf/options/msceqf_option_parser.hpp
+++ b/include/msceqf/options/msceqf_option_parser.hpp
@@ -97,13 +97,19 @@ namespace msceqf
         }
         else if (Cols == 1)
         {
-          utils::Logger::info("Parameter: [" + param + "] found. Option set to: " +
-                              (std::ostringstream{} << x.transpose()).str());
+          utils::Logger::info("Parameter: [" + param + "] found. Option set to: " + ([](const auto& val) {
+            std::ostringstream oss;
+            oss << val;
+            return oss.str();
+          })(x.transpose()));
         }
         else
         {
-          utils::Logger::info("Parameter: [" + param + "] found. Option set to: \n" +
-                              (std::ostringstream{} << x).str());
+          utils::Logger::info("Parameter: [" + param + "] found. Option set to: \n" + ([](const auto& val) {
+            std::ostringstream oss;
+            oss << val;
+            return oss.str();
+          })(x));
         }
 
         return true;
@@ -130,8 +136,11 @@ namespace msceqf
         using vector = std::vector<fp>;
         vector vec = node_[param].as<vector>();
         q = Quaternion(vec).normalize();
-        utils::Logger::info("Parameter: [" + param + "] found. Option set to: \n" +
-                            (std::ostringstream{} << q).str());
+        utils::Logger::info("Parameter: [" + param + "] found. Option set to: \n" + ([](const auto& val) {
+          std::ostringstream oss;
+          oss << val;
+          return oss.str();
+        })(q));
         return true;
       }
       utils::Logger::warn("Parameter: [" + param + "] not found");
@@ -152,8 +161,11 @@ namespace msceqf
       if (node_[param])
       {
         p = node_[param].as<T>();
-        utils::Logger::info("Parameter: [" + param + "] found. Option set to: " +
-                            (std::ostringstream{} << p).str());
+        utils::Logger::info("Parameter: [" + param + "] found. Option set to: " + ([](const auto& val) {
+          std::ostringstream oss;
+          oss << val;
+          return oss.str();
+        })(p));
         return true;
       }
       utils::Logger::warn("Parameter: [" + param + "] not found");
@@ -167,8 +179,11 @@ namespace msceqf
       if (!read(p, param))
       {
         p = def;
-        utils::Logger::warn("Parameter: [" + param + "] set to default value: " +
-                            (std::ostringstream{} << p).str());
+        utils::Logger::warn("Parameter: [" + param + "] set to default value: " + ([](const auto& val) {
+          std::ostringstream oss;
+          oss << val;
+          return oss.str();
+        })(p));
       }
     }
 


### PR DESCRIPTION
Tried to setup MSCEqF on another device that is running GCC 9 leading to the following error:
```
error: ‘class std::basic_ostream<char>’ has no member named ‘str’
```

Tested the changes work on two systems:
- Ubuntu 22.04 with GCC 9.5.0 (build originally failed here)
- Ubuntu 22.04 with GCC 11.4.0