### PR TITLE
Small parameter naming changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,12 +156,14 @@ T_imu_cam:
   - [0.0, 0.0, 0.0, 1.0]
 
 # Initializer options
-# For IMU only motion detection set static_initializer_disparity_threshold: 0.0
+# For IMU only motion detection set checker_disparity_threshold: 0.0
 # For DISPARITY only motion detection set static_initializer_acc_threshold: 0.0
 static_initializer_imu_window: 1.0
-static_initializer_disparity_window: 0.5
 static_initializer_acc_threshold: 0.25
-static_initializer_disparity_threshold: 1.0
+
+# Checker
+checker_disparity_window: 0.5
+checker_disparity_threshold: 1.0
 
 # Propagator options
 # For numerical exponential computation (costly) set state_transition_order: -1

--- a/examples/uzhfpv/config/config.yaml
+++ b/examples/uzhfpv/config/config.yaml
@@ -56,7 +56,7 @@ num_clones: 11
 # Tracker
 equalization_method: histogram
 optical_flow_pyramid_levels: 3
-detection_pyramid_levels: 1
+detector_pyramid_levels: 1
 feature_detector: fast
 grid_x_size: 3
 grid_y_size: 3

--- a/tests/config/parameters.yaml
+++ b/tests/config/parameters.yaml
@@ -25,9 +25,9 @@ T_imu_cam:
 timeshift_cam_imu: 0.0
 
 static_initializer_imu_window: 2.0
-static_initializer_disparity_window: 0.0
 static_initializer_acc_threshold: 0.1
-static_initializer_disparity_threshold: 0.0
+checker_disparity_window: 0.0
+checker_disparity_threshold: 0.0
 identity_bias_origin: false
 init_with_given_state: false
 

--- a/wrappers/ros/ros1/config/template.yaml
+++ b/wrappers/ros/ros1/config/template.yaml
@@ -24,9 +24,11 @@ T_imu_cam:
 
 # Initializer
 static_initializer_imu_window: 1.0
-static_initializer_disparity_window: 0.5
 static_initializer_acc_threshold: 0.0
-static_initializer_disparity_threshold: 1.0
+
+# Checker
+checker_disparity_window: 0.5
+checker_disparity_threshold: 1.0
 
 # Propagator
 state_transition_order: -1


### PR DESCRIPTION
Found some old parameters that were renamed in the sample config files and quickly checked in the code which name is now actually used.

- `static_initializer_disparity_window -> checker_disparity_window`
- `static_initializer_disparity_threshold -> checker_disparity_threshold`